### PR TITLE
Strip dqlite/raft libraries

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -109,6 +109,17 @@ parts:
       - bin/microcloud
       - bin/microcloudd
 
+  strip:
+    after:
+      - dqlite
+      - raft
+    plugin: nil
+    override-prime: |
+      set -x
+
+      # Strip libraries
+      find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +
+
   wrappers:
     plugin: dump
     source: snapcraft/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -101,10 +101,6 @@ parts:
       cd microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
-
-      # Strip binaries
-      strip -s "${CRAFT_PART_INSTALL}/bin/microcloud"
-      strip -s "${CRAFT_PART_INSTALL}/bin/microcloudd"
     prime:
       - bin/microcloud
       - bin/microcloudd
@@ -113,9 +109,13 @@ parts:
     after:
       - dqlite
       - raft
+      - microcloud
     plugin: nil
     override-prime: |
       set -x
+
+      # Strip binaries
+      find "${CRAFT_PRIME}"/bin -type f -exec strip -s {} +
 
       # Strip libraries
       find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +


### PR DESCRIPTION
```
# file /snap/microcloud/current/lib/libdqlite.so.0.0.1 /snap/microcloud/current/lib/libraft.so.3.0.0
/snap/microcloud/current/lib/libdqlite.so.0.0.1: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=5968cf2d677491831517d9591436be8822a2b4e3, with debug_info, not stripped
/snap/microcloud/current/lib/libraft.so.3.0.0:   ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=5f5cc7344fb1e492714210ff5c252897b0e04795, with debug_info, not stripped

# ll -h /snap/microcloud/current/lib/libdqlite.so.0.0.1 /snap/microcloud/current/lib/libraft.so.3.0.0
-rwxr-xr-x 1 root root 1.2M Feb  6 14:49 /snap/microcloud/current/lib/libdqlite.so.0.0.1*
-rwxr-xr-x 1 root root 1.1M Feb  6 14:49 /snap/microcloud/current/lib/libraft.so.3.0.0*
```

Once stripped they go from ~2.3MiB to ~0.4MiB:

```
# ll -h lib*
-rwxr-xr-x 1 root root 204K Feb  6 15:19 libdqlite.so.0.0.1*
-rwxr-xr-x 1 root root 204K Feb  6 15:19 libraft.so.3.0.0*
```

With that in place, all the ELF files are now stripped:

```
# find /snap/microcloud/current -type f -exec file {} + | grep -wF ELF | grep -vF ', stripped'
#
```