### PR TITLE
snap: Add GOCOVERDIR to commands

### DIFF
--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -5,6 +5,9 @@ MICROCLOUDD="microcloudd"
 if [ -x "${SNAP_COMMON}/microcloudd.debug" ]; then
     MICROCLOUDD="${SNAP_COMMON}/microcloudd.debug"
     echo "==> WARNING: Using a custom debug MicroCloud binary!"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
 fi
 
 exec "${MICROCLOUDD}" --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -2,6 +2,9 @@
 MICROCLOUD="microcloud"
 if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
     MICROCLOUD="${SNAP_COMMON}/microcloud.debug"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
 fi
 
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"


### PR DESCRIPTION
This PR creates a GOCOVERDIR in the snap confinement space when using debug binaries.

Note: required for https://github.com/canonical/microcloud/pull/420.