### PR TITLE
dqlite: Use lts-1.17.x branch (v2-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,6 +32,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
+    source-branch: lts-1.17.x
     source-depth: 1
     source-type: git
     plugin: autotools


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>
(cherry picked from commit d534ad10ade08c1a0ef31862f09dfc0ebfad0a44)