### PR TITLE
github: Use version string from local snapcraft file (v2-candidate)

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -52,7 +52,7 @@ jobs:
           GOPROXY=direct go install github.com/canonical/lxd-ci/lxd-snapcraft@latest
           git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~canonical-lxd/microcloud ~/microcloud-pkg-snap-lp
           # XXX: `ver` contains an array with the 2 versions
-          ver=($(lxd-snapcraft -package microcloud -get-version -file ~/microcloud-pkg-snap-lp/snapcraft.yaml))
+          ver=($(lxd-snapcraft -package microcloud -get-version -file snapcraft.yaml))
           rsync -a --exclude .git --delete . ~/microcloud-pkg-snap-lp/
           cd ~/microcloud-pkg-snap-lp
           lxd-snapcraft -package microcloud -set-version "${ver[0]}-${localRev:0:7}" -set-source-commit ""


### PR DESCRIPTION
As the version of the LPs snapcraft.yaml gets rewritten to `<version>-<commit>` for the candidate channel we cannot use the repos updated snapcraft.yaml when crafting the new version. Instead we have to use the raw version from our local snapcraft.yaml file.

This was mistakenly changed whilst backporting https://github.com/canonical/microcloud-pkg-snap/commit/c1bd0307747ad37e6354d2c8bf50753ed59e27e0.
