### PR TITLE
CLI: Include an editor

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -84,10 +84,23 @@ parts:
       - bin/microcloud
       - bin/microcloudd
 
+  vim:
+      plugin: nil
+      stage-packages:
+        - vim-tiny
+      override-build: |
+        touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
+      organize:
+        usr/bin: bin/
+      prime:
+        - bin/vim.tiny
+        - usr/share/vim/vim91/defaults.vim
+
   strip:
     after:
       - dqlite
       - microcloud
+      - vim
     plugin: nil
     override-prime: |
       set -x

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -7,4 +7,11 @@ if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
     mkdir -p "${GOCOVERDIR}"
 fi
 
+# Change the location of $VIMRUNTIME root to be able to define the defaults.vim file.
+# This is to prevent seeing the message 'E1187: Failed to source defaults.vim'
+# which is caused by not having the 'vim-runtime' package.
+# Also see https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912.
+export VIMRUNTIME="/snap/microcloud/current/usr/share/vim/vim91"
+export EDITOR="vim.tiny -Z --clean"
+
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -14,4 +14,7 @@ fi
 export VIMRUNTIME="/snap/microcloud/current/usr/share/vim/vim91"
 export EDITOR="vim.tiny -Z --clean"
 
+# Run the CLI from an accessible directory which allows reads.
+# When launching VIM it tries to access the $PWD regardless of the --clean setting.
+cd "$SNAP_USER_DATA"
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"


### PR DESCRIPTION
Fixes https://github.com/canonical/microcloud/issues/500.

Add a minimal `vim.tiny` to allow commands like `microcloud cluster recover` to spawn an interactive editor for editing the temporary file.
This increases the overall size of the snap to around 11MB (from 10MB). 