### PR TITLE
Add feature.cluster-manager to expose cluster manager subcommands

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -29,6 +29,11 @@ apps:
     plugs:
       - network
 
+hooks:
+  configure:
+    plugs:
+      - system-observe
+
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -14,6 +14,15 @@ fi
 export VIMRUNTIME="/snap/microcloud/current/usr/share/vim/vim91"
 export EDITOR="vim.tiny -Z --clean"
 
+# Set feature flag environment variable based on the snap configuration
+# This can be set/unset with the following commands:
+# snap set microcloud feature.cluster-manager=true
+# snap unset microcloud feature.cluster-manager
+feature_cluster_manager="$(snapctl get feature.cluster-manager)"
+if [ "${feature_cluster_manager:-"false"}" = "true" ]; then
+    export FEATURE_CLUSTER_MANAGER=true
+fi
+
 # Run the CLI from an accessible directory which allows reads.
 # When launching VIM it tries to access the $PWD regardless of the --clean setting.
 cd "$SNAP_USER_DATA"


### PR DESCRIPTION
# Done
- added feature.cluster-manager, so we can do `snap set microcloud feature.cluster-manager=true` to expose the cluster manager subcommands.
- Guard the `microcloud cluster-manager` subcommand with `snap set microcloud feature.cluster-manager=true` and `snap unset microcloud feature.cluster-manager`