### PR TITLE
snapcraft: Bump version of dqlite to v1.17.2 LTS (v2-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,9 +59,8 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
-    source-commit: ee1766cba1b52317ba216c0fbddd8457a0241df6 # v1.17.1 LTS
-    # We often cherry-pick for candidate builds so don't do shallow clone.
-    #source-depth: 1
+    source-commit: 1c3f95492dfb4c649356d5b6f2c031bcd3fd7c0f # v1.17.2 LTS
+    source-depth: 1
     source-type: git
     plugin: autotools
     autotools-configure-parameters:
@@ -82,17 +81,6 @@ parts:
       - lib/libdqlite*so*
       - lib/*/libuv*
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
-    override-build: |
-      set -ex
-
-      # Git cherry-picks
-      cd ../src
-      git config user.email "noreply@lists.canonical.com"
-      git config user.name "LXD snap builder"
-
-      git cherry-pick -x b18dfbc3f9f89ed219611e88bad1fa17d1e9e818 # Segfault fix
-
-      craftctl default
 
   microcloud:
     source: https://github.com/canonical/microcloud


### PR DESCRIPTION
Bump version of dqlite to `v.1.17.2`. See https://github.com/canonical/dqlite/releases/tag/v1.17.2