### PR TITLE
snapcraft: Set full AGPL-3.0-only license identifier

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ assumes:
  - snapd2.59
 version: git
 grade: devel
-license: AGPL-3.0
+license: AGPL-3.0-only
 
 title: MicroCloud
 summary: Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.


### PR DESCRIPTION
The `AGPL-3.0` license identifier is deprecated.

`AGPL-3.0-only` is already set for MicroCloud and I just missed it in the [previous PR](https://github.com/canonical/microcloud-pkg-snap/pull/66) when setting the license.