### PR TITLE
snapcraft: Set full AGPL-3.0-only license identifier (v2-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ assumes:
  - snapd2.59
 version: "2.1.0"
 grade: stable
-license: AGPL-3.0
+license: AGPL-3.0-only
 
 title: MicroCloud
 summary: Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.


### PR DESCRIPTION
The AGPL-3.0 license identifier is deprecated.

(cherry picked from commit 6a01e0169c13327583bb122385eb7ac57d18a182)