### PR TITLE
snapcraft: Pin version of Go used during MicroCloud build (v2-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -89,7 +89,7 @@ parts:
     after:
       - dqlite
     build-snaps:
-      - go
+      - go/1.24/stable
     plugin: nil
     override-pull: |
       craftctl default


### PR DESCRIPTION
Right now it picks go/latest/stable which translates to go/1.24/stable.