### PR TITLE
snapcraft: Use dqlite LTS for edge

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
+    source-branch: lts-1.17.x
     source-depth: 1
     source-type: git
     plugin: autotools


### PR DESCRIPTION
MicroCloud v3 is using Microcluster v2 which uses go-dqlite v2 which should be used with dqlite LTS. Only when MicroCloud v3 starts using Microcluster v3 (and go-dqlite v3) we should use dqlite from its master branch.

Follow up on https://github.com/canonical/microcloud/pull/957 for the actual snap build.