### PR TITLE
snapcraft: Use dqlite main branch (latest-edge)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,7 +59,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
-    source-branch: lts-1.17.x
+    source-branch: main
     source-depth: 1
     source-type: git
     plugin: autotools


### PR DESCRIPTION
Now that MicroCloud v3 is using the latest Microcluster v3 (which uses the latest go-dqlite v3), we should also use dqlite's `main` branch when building the dependencies.

Merge after https://github.com/canonical/microcloud/pull/1018.