### PR TITLE
Backports from `latest-edge` (latest-candidate)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
 updates:
+  # Check the current default edge branch.
   - package-ecosystem: "github-actions"
     directory: "/"
     labels: []
     schedule:
       interval: "weekly"
+
+  # Also check other (non-default) edge branches.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "v2-edge"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Also check other (non-default) edge branches.
   - package-ecosystem: "github-actions"
@@ -14,6 +20,12 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "v2-edge"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Also check the candidate branches.
   - package-ecosystem: "github-actions"
@@ -22,3 +34,9 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "v2-candidate"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "v2-edge"
+
+  # Also check the candidate branches.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "v2-candidate"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,7 +15,7 @@ jobs:
   snap:
     name: Trigger snap build
     runs-on: ubuntu-24.04
-    if: ${{ github.repository == 'canonical/microcloud-pkg-snap' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.repository == 'canonical/microcloud-pkg-snap' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       PACKAGE: "microcloud"

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   snap:
     name: Trigger snap build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: ${{ github.repository == 'canonical/microcloud-pkg-snap' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.23.x
 
       - name: Trigger Launchpad snap build
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Install Go
         uses: actions/setup-go@v4
+        with:
+          go-version: 1.21.x
 
       - name: Trigger Launchpad snap build
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -33,11 +33,11 @@ jobs:
         run: |
           set -eux
           localRev="$(git rev-parse HEAD)"
-          # XXX: `ver` contains an array with the 2 versions
-          ver=($(lxd-snapcraft -package "${PACKAGE}" -get-version -file ~/"${PACKAGE}-pkg-snap-lp/snapcraft.yaml"))
+          # XXX: `originVer` contains an array with the 2 versions
+          originVer=($(lxd-snapcraft -package "${PACKAGE}" -get-version -file snapcraft.yaml))
           rsync -a --exclude .git --delete . ~/"${PACKAGE}-pkg-snap-lp"/
           cd ~/"${PACKAGE}-pkg-snap-lp"
-          lxd-snapcraft -package "${PACKAGE}" -set-version "${ver[0]}" -set-source-commit "${ver[1]}"
+          lxd-snapcraft -package "${PACKAGE}" -set-version "${originVer[0]}-${localRev:0:7}" -set-source-commit ""
           git add --all
           git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
           git show

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,8 +14,8 @@ concurrency:
 jobs:
   snap:
     name: Trigger snap build
-    runs-on: ubuntu-24.04
-    if: ${{ github.repository == 'canonical/microcloud-pkg-snap' && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository == 'canonical/microcloud-pkg-snap' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       PACKAGE: "microcloud"
@@ -25,43 +25,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - name: Setup Launchpad SSH access
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          LAUNCHPAD_LXD_BOT_KEY: ${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}
-        run: |
-          set -eux
-          mkdir -m 0700 -p ~/.ssh/
-          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
-          ssh-add - <<< "${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}"
-          ssh-add -L > ~/.ssh/id_ed25519.pub
-          # In ephemeral environments like GitHub Action runners, relying on TOFU isn't providing any security
-          # so require the key obtained by `ssh-keyscan` to match the expected hash from https://help.launchpad.net/SSHFingerprints
-          ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
-          ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
-
-      - name: Install Go
-        uses: actions/setup-go@v4
+      - uses: canonical/lxd/.github/actions/lp-snap-build@main
         with:
-          go-version: 1.23.x
+          ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}"
 
       - name: Trigger Launchpad snap build
         run: |
           set -eux
-          git config --global transfer.fsckobjects true
-          git config --global user.name "Canonical LXD Bot"
-          git config --global user.email "lxd@lists.canonical.com"
-          git config --global commit.gpgsign true
-          git config --global gpg.format "ssh"
-          git config --global user.signingkey ~/.ssh/id_ed25519.pub
           localRev="$(git rev-parse HEAD)"
-          GOPROXY=direct go install github.com/canonical/lxd-ci/lxd-snapcraft@latest
-          git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud ~/microcloud-pkg-snap-lp
           # XXX: `ver` contains an array with the 2 versions
-          ver=($(lxd-snapcraft -package microcloud -get-version -file ~/microcloud-pkg-snap-lp/snapcraft.yaml))
-          rsync -a --exclude .git --delete . ~/microcloud-pkg-snap-lp/
-          cd ~/microcloud-pkg-snap-lp
-          lxd-snapcraft -package microcloud -set-version "${ver[0]}" -set-source-commit "${ver[1]}"
+          ver=($(lxd-snapcraft -package "${PACKAGE}" -get-version -file ~/"${PACKAGE}-pkg-snap-lp/snapcraft.yaml"))
+          rsync -a --exclude .git --delete . ~/"${PACKAGE}-pkg-snap-lp"/
+          cd ~/"${PACKAGE}-pkg-snap-lp"
+          lxd-snapcraft -package "${PACKAGE}" -set-version "${ver[0]}" -set-source-commit "${ver[1]}"
           git add --all
           git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
           git show

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,19 +25,41 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
-      - uses: canonical/lxd/.github/actions/lp-snap-build@main
-        with:
-          ssh-key: "${{ secrets.LAUNCHPAD_LXD_BOT_KEY}}"
+      - name: Setup Launchpad SSH access
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          LAUNCHPAD_LXD_BOT_KEY: ${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}
+        run: |
+          set -eux
+          mkdir -m 0700 -p ~/.ssh/
+          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
+          ssh-add - <<< "${{ secrets.LAUNCHPAD_LXD_BOT_KEY }}"
+          ssh-add -L > ~/.ssh/id_ed25519.pub
+          # In ephemeral environments like GitHub Action runners, relying on TOFU isn't providing any security
+          # so require the key obtained by `ssh-keyscan` to match the expected hash from https://help.launchpad.net/SSHFingerprints
+          ssh-keyscan git.launchpad.net >> ~/.ssh/known_hosts
+          ssh-keygen -qlF git.launchpad.net | grep -xF 'git.launchpad.net RSA SHA256:UNOzlP66WpDuEo34Wgs8mewypV0UzqHLsIFoqwe8dYo'
+
+      - name: Install Go
+        uses: actions/setup-go@v4
 
       - name: Trigger Launchpad snap build
         run: |
           set -eux
+          git config --global transfer.fsckobjects true
+          git config --global user.name "Canonical LXD Bot"
+          git config --global user.email "lxd@lists.canonical.com"
+          git config --global commit.gpgsign true
+          git config --global gpg.format "ssh"
+          git config --global user.signingkey ~/.ssh/id_ed25519.pub
           localRev="$(git rev-parse HEAD)"
-          # XXX: `originVer` contains an array with the 2 versions
-          originVer=($(lxd-snapcraft -package "${PACKAGE}" -get-version -file snapcraft.yaml))
-          rsync -a --exclude .git --delete . ~/"${PACKAGE}-pkg-snap-lp"/
-          cd ~/"${PACKAGE}-pkg-snap-lp"
-          lxd-snapcraft -package "${PACKAGE}" -set-version "${originVer[0]}-${localRev:0:7}" -set-source-commit ""
+          GOPROXY=direct go install github.com/canonical/lxd-ci/lxd-snapcraft@latest
+          git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~canonical-lxd/microcloud ~/microcloud-pkg-snap-lp
+          # XXX: `ver` contains an array with the 2 versions
+          ver=($(lxd-snapcraft -package microcloud -get-version -file ~/microcloud-pkg-snap-lp/snapcraft.yaml))
+          rsync -a --exclude .git --delete . ~/microcloud-pkg-snap-lp/
+          cd ~/microcloud-pkg-snap-lp
+          lxd-snapcraft -package microcloud -set-version "${ver[0]}" -set-source-commit "${ver[1]}"
           git add --all
           git commit --all --quiet -s --allow-empty -m "Automatic upstream build (${BRANCH})" -m "Upstream commit: ${localRev}"
           git show

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -56,7 +56,7 @@ jobs:
           git config --global user.signingkey ~/.ssh/id_ed25519.pub
           localRev="$(git rev-parse HEAD)"
           GOPROXY=direct go install github.com/canonical/lxd-ci/lxd-snapcraft@latest
-          git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~canonical-lxd/microcloud ~/microcloud-pkg-snap-lp
+          git clone -b "${TARGET}" git+ssh://lxdbot@git.launchpad.net/~microcloud-snap/microcloud ~/microcloud-pkg-snap-lp
           # XXX: `ver` contains an array with the 2 versions
           ver=($(lxd-snapcraft -package microcloud -get-version -file ~/microcloud-pkg-snap-lp/snapcraft.yaml))
           rsync -a --exclude .git --delete . ~/microcloud-pkg-snap-lp/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# **MicroCloud**
+
+This repository contains the snap packaging for [MicroCloud](https://snapcraft.io/microcloud) and the sources for MicroCloud itself are at: https://github.com/canonical/microcloud
+
+The MicroCloud snaps are built for various architectures on Launchpad:
+
+* [`latest/candidate`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-candidate)
+* [`latest/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-edge)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains the snap packaging for [MicroCloud](https://snapcraft.i
 
 The MicroCloud snaps are built for various architectures on Launchpad:
 
+* [`1/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v1-edge)
+* [`1/candidate`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v1-candidate)
+* [`2/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v2-edge)
 * [`2/candidate`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v2-candidate)
 * [`2/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v2-edge)
 * [`3/edge` & `latest/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-latest-edge)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@ This repository contains the snap packaging for [MicroCloud](https://snapcraft.i
 
 The MicroCloud snaps are built for various architectures on Launchpad:
 
-* [`2/candidate`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-v2-candidate)
-* [`2/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-v2-edge)
-* [`3/edge` & `latest/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-edge)
+* [`2/candidate`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v2-candidate)
+* [`2/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-v2-edge)
+* [`3/edge` & `latest/edge`](https://launchpad.net/~microcloud-snap/microcloud/+snap/microcloud-latest-edge)

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This repository contains the snap packaging for [MicroCloud](https://snapcraft.i
 
 The MicroCloud snaps are built for various architectures on Launchpad:
 
-* [`latest/candidate`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-candidate)
-* [`latest/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-edge)
+* [`2/candidate`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-v2-candidate)
+* [`2/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-v2-edge)
+* [`3/edge` & `latest/edge`](https://launchpad.net/~canonical-lxd/microcloud/+snap/microcloud-latest-edge)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,17 +11,6 @@ description: |-
 
 confinement: strict
 
-plugs:
- ovn-env:
-   interface: content
-   target: "$SNAP_DATA/microovn/env"
- ovn-certificates:
-   interface: content
-   target: "$SNAP_DATA/microovn/certificates"
- ovn-chassis:
-   interface: content
-   target: "$SNAP_DATA/microovn/chassis"
-
 apps:
   # Service
   daemon:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -11,6 +11,17 @@ description: |-
 
 confinement: strict
 
+plugs:
+ ovn-env:
+   interface: content
+   target: "$SNAP_DATA/microovn/env"
+ ovn-certificates:
+   interface: content
+   target: "$SNAP_DATA/microovn/certificates"
+ ovn-chassis:
+   interface: content
+   target: "$SNAP_DATA/microovn/chassis"
+
 apps:
   # Service
   daemon:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: microcloud
-base: core22
+base: core24
 assumes:
  - snapd2.59
 version: "1.1"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,6 +53,17 @@ parts:
       - lib/libdqlite*so*
       - lib/*/libuv*
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
+    override-build: |
+      set -ex
+
+      # Git cherry-picks
+      cd ../src
+      git config user.email "noreply@lists.canonical.com"
+      git config user.name "LXD snap builder"
+
+      git cherry-pick -x b18dfbc3f9f89ed219611e88bad1fa17d1e9e818 # Segfault fix
+
+      craftctl default
 
   microcloud:
     source: https://github.com/canonical/microcloud

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -122,6 +122,10 @@ parts:
       cd microcloud
       go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+
+      # Strip binaries
+      strip -s "${SNAPCRAFT_PART_INSTALL}/bin/microcloud"
+      strip -s "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd"
     prime:
       - bin/microcloud
       - bin/microcloudd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -73,6 +73,7 @@ parts:
     prime:
       - lib/libraft*so*
       - lib/*/libuv.so*
+      #- lib/*/liblz4.so*  # use liblz4.so from the base snap
 
   microcloud:
     source: https://github.com/canonical/microcloud

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -111,18 +111,18 @@ parts:
       git cherry-pick f19707ad48062c350947a3b432a1e6a6022c638e # microcloud/service: Properly broadcast available interfaces over those interfaces
 
       # Setup build environment
-      export CGO_CFLAGS="-I${SNAPCRAFT_STAGE}/include/ -I${SNAPCRAFT_STAGE}/usr/local/include/"
-      export CGO_LDFLAGS="-L${SNAPCRAFT_STAGE}/lib/ -L${SNAPCRAFT_STAGE}/usr/local/lib/"
+      export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
+      export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
       # Build the binaries
       cd microcloud
-      go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
-      go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
+      go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
 
       # Strip binaries
-      strip -s "${SNAPCRAFT_PART_INSTALL}/bin/microcloud"
-      strip -s "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd"
+      strip -s "${CRAFT_PART_INSTALL}/bin/microcloud"
+      strip -s "${CRAFT_PART_INSTALL}/bin/microcloudd"
     prime:
       - bin/microcloud
       - bin/microcloudd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -87,7 +87,7 @@ parts:
       - go
     plugin: nil
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       set -ex
 
       # Download the dependencies

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -120,8 +120,8 @@ parts:
 
       # Build the binaries
       cd microcloud
-      go build -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
-      go build -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+      go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
+      go build -trimpath -o "${SNAPCRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
     prime:
       - bin/microcloud
       - bin/microcloudd

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -120,10 +120,6 @@ parts:
       cd microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
-
-      # Strip binaries
-      strip -s "${CRAFT_PART_INSTALL}/bin/microcloud"
-      strip -s "${CRAFT_PART_INSTALL}/bin/microcloudd"
     prime:
       - bin/microcloud
       - bin/microcloudd
@@ -132,9 +128,13 @@ parts:
     after:
       - dqlite
       - raft
+      - microcloud
     plugin: nil
     override-prime: |
       set -x
+
+      # Strip binaries
+      find "${CRAFT_PRIME}"/bin -type f -exec strip -s {} +
 
       # Strip libraries
       find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -53,17 +53,6 @@ parts:
       - lib/libdqlite*so*
       - lib/*/libuv*
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
-    override-build: |
-      set -ex
-
-      # Git cherry-picks
-      cd ../src
-      git config user.email "noreply@lists.canonical.com"
-      git config user.name "LXD snap builder"
-
-      git cherry-pick -x b18dfbc3f9f89ed219611e88bad1fa17d1e9e818 # Segfault fix
-
-      craftctl default
 
   microcloud:
     source: https://github.com/canonical/microcloud

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,7 +31,6 @@ apps:
 
 parts:
   dqlite:
-    build-attributes: [core22-step-dependencies]
     after:
       - raft
     source: https://github.com/canonical/dqlite
@@ -55,7 +54,6 @@ parts:
       - lib/*/libuv*
 
   raft:
-    build-attributes: [core22-step-dependencies]
     source: https://github.com/canonical/raft
     source-tag: v0.18.0
     source-type: git
@@ -77,7 +75,6 @@ parts:
       - lib/*/libuv.so*
 
   microcloud:
-    build-attributes: [core22-step-dependencies]
     source: https://github.com/canonical/microcloud
     source-commit: 4b02c16672e22c41ff7515d10717f373b6a25349 # MicroCloud 1.1
     source-type: git

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -128,6 +128,17 @@ parts:
       - bin/microcloud
       - bin/microcloudd
 
+  strip:
+    after:
+      - dqlite
+      - raft
+    plugin: nil
+    override-prime: |
+      set -x
+
+      # Strip libraries
+      find "${CRAFT_PRIME}"/lib -type f -exec strip -s {} +
+
   wrappers:
     plugin: dump
     source: snapcraft/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,6 +59,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
+    source-branch: lts-1.17.x
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -102,10 +102,23 @@ parts:
       - bin/microcloud
       - bin/microcloudd
 
+  vim:
+      plugin: nil
+      stage-packages:
+        - vim-tiny
+      override-build: |
+        touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
+      organize:
+        usr/bin: bin/
+      prime:
+        - bin/vim.tiny
+        - usr/share/vim/vim91/defaults.vim
+
   strip:
     after:
       - dqlite
       - microcloud
+      - vim
     plugin: nil
     override-prime: |
       set -x

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -59,7 +59,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
-    source-branch: lts-1.17.x
+    source-branch: main
     source-depth: 1
     source-type: git
     plugin: autotools

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -31,19 +31,19 @@ apps:
 
 parts:
   dqlite:
-    after:
-      - raft
     source: https://github.com/canonical/dqlite
-    source-tag: v1.16.0
-    source-type: git
     source-depth: 1
+    source-type: git
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=
+      - --enable-build-raft
     stage-packages:
+      - liblz4-1
       - libsqlite3-0
       - libuv1
     build-packages:
+      - liblz4-dev
       - libsqlite3-dev
       - libuv1-dev
       - pkg-config
@@ -52,27 +52,6 @@ parts:
     prime:
       - lib/libdqlite*so*
       - lib/*/libuv*
-
-  raft:
-    source: https://github.com/canonical/raft
-    source-tag: v0.18.0
-    source-type: git
-    source-depth: 1
-    plugin: autotools
-    autotools-configure-parameters:
-      - --prefix=
-    stage-packages:
-      - libuv1
-      - liblz4-1
-    build-packages:
-      - libuv1-dev
-      - liblz4-dev
-      - pkg-config
-    organize:
-      usr/lib/: lib/
-    prime:
-      - lib/libraft*so*
-      - lib/*/libuv.so*
       #- lib/*/liblz4.so*  # use liblz4.so from the base snap
 
   microcloud:
@@ -127,7 +106,6 @@ parts:
   strip:
     after:
       - dqlite
-      - raft
       - microcloud
     plugin: nil
     override-prime: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,8 +2,8 @@ name: microcloud
 base: core24
 assumes:
  - snapd2.59
-version: git
-grade: devel
+version: "3.1"
+grade: stable
 license: AGPL-3.0-only
 
 title: MicroCloud
@@ -59,7 +59,7 @@ apps:
 parts:
   dqlite:
     source: https://github.com/canonical/dqlite
-    source-branch: main
+    source-branch: v1.18.x
     source-depth: 1
     source-type: git
     plugin: autotools
@@ -84,12 +84,13 @@ parts:
 
   microcloud:
     source: https://github.com/canonical/microcloud
-    source-commit: 4b02c16672e22c41ff7515d10717f373b6a25349 # MicroCloud 1.1
+    source-commit: 641f3c6a6ac7bae8ba1e7651bd0319761111142f # 3.1
+    source-depth: 1
     source-type: git
     after:
       - dqlite
     build-snaps:
-      - go
+      - go/1.25/stable
     plugin: nil
     override-pull: |
       craftctl default
@@ -103,27 +104,12 @@ parts:
       git config user.email "noreply@lists.canonical.com"
       git config user.name "MicroCloud snap builder"
 
-      git cherry-pick e50cd006e8773a3dfaa020c9997eb7789253ee15 # microcloud/cmd/microcloud: Use stdin for preseed.yaml
-      git cherry-pick b1553cb2f3ea111fb497e1d60cec7b3eec9680c6 # microcloud/test/suites: Rename conflicting variable name
-      git cherry-pick b19d1b537e9b9099bb5ddd2f8643ec302a4d1b54 # microcloud/test/includes: Default to edge snap if local one not provided
-      git cherry-pick 404827f070282e47f3a033638587f460dd5c034a # microcloud/test/includes: Fix instance removal between tests
-      git cherry-pick 00d6fca0db2503f29477ea124162ba7a267ba69f # microcloud/service: Add ZFS pool description
-      git cherry-pick 6700eabb7ce0dfe4fb3c3d95fad7e260e4486a66 # microcloud/mdns: Include net.Interface in NetworkInfo
-      git cherry-pick 201968ec5191d7ddfecca700be6c1efdd58b49c9 # microcloud/mdns: Pass the interface to the mdns handler
-      git cherry-pick 71567eadb4192fd1242820584069c29077f7fd7c # microcloud/cmd/microcloud: Pass network interface through initial networking questions
-      git cherry-pick 283efac02aeea6006c39201b939bb774e426bdfe # microcloud/cmd/microcloud: Update usages of askAddress and NetworkInfo
-      git cherry-pick 4e0da91debc563c8eb5cfbc3170d1dd0d13de7ba # microcloud/cmd/microcloud: Add option to specify interface in preseed
-      git cherry-pick 88c7ef73819f2a01e7e7161d685f50860a1b1072 # microcloud/test/suites: Update preseed test
-      git cherry-pick a8584be34dea149e736a2c8e9a1d902523911618 # microcloud/test/includes: Fix typo in testsuite
-      git cherry-pick f19707ad48062c350947a3b432a1e6a6022c638e # microcloud/service: Properly broadcast available interfaces over those interfaces
-
       # Setup build environment
       export CGO_CFLAGS="-I${CRAFT_STAGE}/include/ -I${CRAFT_STAGE}/usr/local/include/"
       export CGO_LDFLAGS="-L${CRAFT_STAGE}/lib/ -L${CRAFT_STAGE}/usr/local/lib/"
       export CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
       # Build the binaries
-      cd microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,17 +7,17 @@ grade: devel
 license: AGPL-3.0-only
 
 title: MicroCloud
-summary: Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.
+summary: Deploy a low-touch, open source cloud platform in minutes with MicroCloud.
 description: |-
-  MicroCloud creates a lightweight cluster of machines that operates as an open source private cloud. It combines LXD for virtualisation, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the **MicroCloud snap** for reproducible, reliable deployments.
+  MicroCloud creates a lightweight cluster of machines that operates as a scalable private cloud. It combines LXD for virtualization, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the **MicroCloud snap** for reproducible, scalable deployments.
 
-  With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from high availability, automatic security updates, and the advanced features of its components such as self-healing clusters and fine-grained access control. Cluster members can run full virtual machines or lightweight system containers with bare-metal performance.
+  With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from high availability, streamlined security updates, and fine-grained access control for multi-tenancy. Cluster members can run full virtual machines or lightweight system containers with bare-metal performance. Manage it through your choice of client interfaces, including a graphical UI and CLI.
 
   MicroCloud is designed for small-scale private clouds and hybrid cloud extensions. Its efficiency and simplicity also make it an excellent choice for edge computing, test labs, and other resource-constrained use cases.
 
   **MicroCloud supports single-node deployments, but at least 3 nodes are recommended for high availability.**
 
-  Once the simple bootstrapping is completed, users can launch, run and manage their workloads using system containers or VMs, and otherwise utilize regular LXD functionalities.
+  Once the simple bootstrapping is completed, users can launch, run and manage their workloads, and otherwise utilize regular LXD functionalities.
 
   To get started, LXD, MicroCeph, MicroOVN and MicroCloud snaps are needed. Users can install them at once with the command:
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -68,8 +68,7 @@ parts:
       set -ex
 
       # Download the dependencies
-      cd microcloud
-      go get -d -v -tags=agent ./...
+      go get -v -tags=agent ./...
     override-build: |
       set -ex
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,13 +2,40 @@ name: microcloud
 base: core24
 assumes:
  - snapd2.59
-version: "1.1"
-grade: stable
-source-code: https://github.com/canonical/microcloud.git
-summary: Fully automated private clouds
-description: |-
- Fully automated private clouds.
+version: git
+grade: devel
+license: AGPL-3.0
 
+title: MicroCloud
+summary: Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.
+description: |-
+  MicroCloud creates a lightweight cluster of machines that operates as an open source private cloud. It combines LXD for virtualisation, MicroCeph for distributed storage, and MicroOVN for networking—all automatically configured by the **MicroCloud snap** for reproducible, reliable deployments.
+
+  With MicroCloud, you can eliminate the complexity of manual setup and quickly benefit from high availability, automatic security updates, and the advanced features of its components such as self-healing clusters and fine-grained access control. Cluster members can run full virtual machines or lightweight system containers with bare-metal performance.
+
+  MicroCloud is designed for small-scale private clouds and hybrid cloud extensions. Its efficiency and simplicity also make it an excellent choice for edge computing, test labs, and other resource-constrained use cases.
+
+  **MicroCloud supports single-node deployments, but at least 3 nodes are recommended for high availability.**
+
+  Once the simple bootstrapping is completed, users can launch, run and manage their workloads using system containers or VMs, and otherwise utilize regular LXD functionalities.
+
+  To get started, LXD, MicroCeph, MicroOVN and MicroCloud snaps are needed. Users can install them at once with the command:
+
+  `snap install lxd microceph microcloud microovn`
+
+  The bootstrapping process starts with running
+
+  `microcloud init` on the initiating member
+  and `microcloud join` on the joining members if you're using more than one system.
+
+  Following the simple CLI prompts, a working MicroCloud will be ready within minutes.
+
+contact: lxd@lists.canonical.com
+issues: https://github.com/canonical/microcloud/issues
+source-code: https://github.com/canonical/microcloud
+website:
+  - https://canonical.com/microcloud
+  - https://documentation.ubuntu.com/microcloud/latest/microcloud/
 confinement: strict
 
 apps:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -98,27 +98,19 @@ parts:
       cd microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+
+      # Workaround for https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/vim/vim91"
+      touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
     prime:
       - bin/microcloud
       - bin/microcloudd
-
-  vim:
-      plugin: nil
-      stage-packages:
-        - vim-tiny
-      override-build: |
-        touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
-      organize:
-        usr/bin: bin/
-      prime:
-        - bin/vim.tiny
-        - usr/share/vim/vim91/defaults.vim
+      - usr/share/vim/vim91/defaults.vim
 
   strip:
     after:
       - dqlite
       - microcloud
-      - vim
     plugin: nil
     override-prime: |
       set -x

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -4,7 +4,7 @@ assumes:
  - snapd2.59
 version: git
 grade: devel
-license: AGPL-3.0
+license: AGPL-3.0-only
 
 title: MicroCloud
 summary: Deploy a scalable, low-touch cloud platform in minutes with MicroCloud.

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -1,4 +1,10 @@
 #!/bin/sh
 export DQLITE_SOCKET="@snap.${SNAP_INSTANCE_NAME}.dqlite"
 
-exec microcloudd --state-dir "${SNAP_COMMON}/state"
+MICROCLOUDD="microcloudd"
+if [ -x "${SNAP_COMMON}/microcloudd.debug" ]; then
+    MICROCLOUDD="${SNAP_COMMON}/microcloudd.debug"
+    echo "==> WARNING: Using a custom debug MicroCloud binary!"
+fi
+
+exec "${MICROCLOUDD}" --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/daemon.start
+++ b/snapcraft/commands/daemon.start
@@ -5,6 +5,9 @@ MICROCLOUDD="microcloudd"
 if [ -x "${SNAP_COMMON}/microcloudd.debug" ]; then
     MICROCLOUDD="${SNAP_COMMON}/microcloudd.debug"
     echo "==> WARNING: Using a custom debug MicroCloud binary!"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
 fi
 
 exec "${MICROCLOUDD}" --state-dir "${SNAP_COMMON}/state"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -1,2 +1,7 @@
 #!/bin/sh
-exec microcloud --state-dir "${SNAP_COMMON}/state" "$@"
+MICROCLOUD="microcloud"
+if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
+    MICROCLOUD="${SNAP_COMMON}/microcloud.debug"
+fi
+
+exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -2,6 +2,9 @@
 MICROCLOUD="microcloud"
 if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
     MICROCLOUD="${SNAP_COMMON}/microcloud.debug"
+    GOCOVERDIR="${SNAP_COMMON}/data/cover"
+    export GOCOVERDIR
+    mkdir -p "${GOCOVERDIR}"
 fi
 
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -7,4 +7,11 @@ if [ -x "${SNAP_COMMON}/microcloud.debug" ]; then
     mkdir -p "${GOCOVERDIR}"
 fi
 
+# Change the location of $VIMRUNTIME root to be able to define the defaults.vim file.
+# This is to prevent seeing the message 'E1187: Failed to source defaults.vim'
+# which is caused by not having the 'vim-runtime' package.
+# Also see https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912.
+export VIMRUNTIME="/snap/microcloud/current/usr/share/vim/vim91"
+export EDITOR="vim.tiny -Z --clean"
+
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"

--- a/snapcraft/commands/microcloud
+++ b/snapcraft/commands/microcloud
@@ -14,4 +14,7 @@ fi
 export VIMRUNTIME="/snap/microcloud/current/usr/share/vim/vim91"
 export EDITOR="vim.tiny -Z --clean"
 
+# Run the CLI from an accessible directory which allows reads.
+# When launching VIM it tries to access the $PWD regardless of the --clean setting.
+cd "$SNAP_USER_DATA"
 exec "${MICROCLOUD}" --state-dir "${SNAP_COMMON}/state" "$@"


### PR DESCRIPTION
We never used feature releases in MicroCloud. Therefore the `latest-candidate` branch was never used/updated.

In order to prepare for 3.1, this PR contains backports from `latest-edge` as well as some preparations for the `snapcraft.yaml` file to accommodate 3.1