### PR TITLE
github: Let dependabot check latest-candidate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,19 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+    target-branch: "latest-candidate"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
     target-branch: "v2-candidate"
     cooldown:
       default-days: 7


### PR DESCRIPTION
Should be merged after https://github.com/canonical/microcloud-pkg-snap/pull/93 to let dependabot propose changes on the latest changes in `latest-candidate`.