### PR TITLE
Backport dropping vim (v2-candidate)

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -113,9 +113,14 @@ parts:
       # Build the binaries
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloud" -tags=agent ./cmd/microcloud
       go build -trimpath -o "${CRAFT_PART_INSTALL}/bin/microcloudd" -tags=agent,libsqlite3 ./cmd/microcloudd
+
+      # Workaround for https://bugs.launchpad.net/ubuntu/+source/vim/+bug/1968912
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/vim/vim91"
+      touch "${CRAFT_PART_INSTALL}/usr/share/vim/vim91/defaults.vim"
     prime:
       - bin/microcloud
       - bin/microcloudd
+      - usr/share/vim/vim91/defaults.vim
 
   strip:
     after:


### PR DESCRIPTION
I was just comparing `v2-candidate` with `latest-edge` and found this commit is missing. https://github.com/canonical/microcloud-pkg-snap/pull/62.

(cherry picked from commit 05bdb94a5cc2fbda61fb015ab06010d554ce56de)