### PR TITLE
snapcraft.yaml: update MicroCloud docs URL

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -35,7 +35,7 @@ issues: https://github.com/canonical/microcloud/issues
 source-code: https://github.com/canonical/microcloud
 website:
   - https://canonical.com/microcloud
-  - https://documentation.ubuntu.com/microcloud/latest/microcloud/
+  - https://canonical.com/microcloud/docs/latest/microcloud/
 confinement: strict
 
 apps:


### PR DESCRIPTION
Updates the MicroCloud URL following the migration to canonical.com and updates the `latest` home page, which no longer includes the final `microcloud` part of the path.